### PR TITLE
Discard master-slave words

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,8 +69,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Wetterturnier Wordpress Plugin'
@@ -257,7 +257,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'Wetterturnier.tex', u'Wetterturnier Documentation',
+  (main_doc, 'Wetterturnier.tex', u'Wetterturnier Documentation',
    u'Reto', 'manual'),
 ]
 
@@ -287,7 +287,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'wetterturnier', u'Wetterturnier Documentation',
+    (main_doc, 'wetterturnier', u'Wetterturnier Documentation',
      [author], 1)
 ]
 
@@ -301,7 +301,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'Wetterturnier', u'Wetterturnier Documentation',
+  (main_doc, 'Wetterturnier', u'Wetterturnier Documentation',
    author, 'Wetterturnier', 'One line description of project.',
    'Miscellaneous'),
 ]


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.